### PR TITLE
Fix null listing crash

### DIFF
--- a/src/mappings/diamond.ts
+++ b/src/mappings/diamond.ts
@@ -391,8 +391,10 @@ export function handleSetAavegotchiName(event: SetAavegotchiName): void {
       gotchi.activeListing!.toString(),
       false
     );
-    listing.nameLowerCase = gotchi.nameLowerCase;
-    listing.save();
+    if (listing) {
+      listing.nameLowerCase = gotchi.nameLowerCase;
+      listing.save();
+    }
   }
 }
 
@@ -499,8 +501,10 @@ export function handleAavegotchiInteract(event: AavegotchiInteract): void {
       gotchi.activeListing!.toString(),
       false
     );
-    listing.kinship = gotchi.kinship;
-    listing.save();
+    if (listing) {
+      listing.kinship = gotchi.kinship;
+      listing.save();
+    }
   }
 }
 

--- a/src/mappings/polter.ts
+++ b/src/mappings/polter.ts
@@ -381,8 +381,10 @@ export function handleSetAavegotchiName(event: SetAavegotchiName): void {
       gotchi.activeListing!.toString(),
       false
     );
-    listing.nameLowerCase = gotchi.nameLowerCase;
-    listing.save();
+    if (listing) {
+      listing.nameLowerCase = gotchi.nameLowerCase;
+      listing.save();
+    }
   }
 }
 

--- a/src/utils/helpers/aavegotchi.ts
+++ b/src/utils/helpers/aavegotchi.ts
@@ -114,7 +114,7 @@ export function getOrCreateUser(
 export function getOrCreateERC721Listing(
   id: string,
   createIfNotFound: boolean = true
-): ERC721Listing {
+): ERC721Listing | null {
   let listing = ERC721Listing.load(id);
 
   if (listing == null && createIfNotFound) {
@@ -123,7 +123,7 @@ export function getOrCreateERC721Listing(
     listing.timeCreated = BIGINT_ZERO;
   }
 
-  return listing as ERC721Listing;
+  return listing;
 }
 
 export function getOrCreateERC1155Listing(
@@ -463,7 +463,7 @@ export function updateAavegotchiInfo(
     }
 
     if (gotchi.activeListing && updateListing) {
-      let listing = getOrCreateERC721Listing(gotchi.activeListing!.toString());
+      let listing = getOrCreateERC721Listing(gotchi.activeListing!.toString())!;
       listing.kinship = gotchi.kinship;
       listing.experience = gotchi.experience;
       listing.nameLowerCase = gotchi.nameLowerCase;


### PR DESCRIPTION
## Summary
- allow getOrCreateERC721Listing to return null
- guard listing updates in SetAavegotchiName and handleAavegotchiInteract

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6853a7f066848325832ba2ca9c0e96ae