### PR TITLE
Fix interact handler for missing listing

### DIFF
--- a/src/mappings/baseDiamond.ts
+++ b/src/mappings/baseDiamond.ts
@@ -117,7 +117,7 @@ import {
 } from "../utils/constants";
 import { Address, BigInt, log, Bytes } from "@graphprotocol/graph-ts";
 
-import { Parcel, TokenCommitment } from "../../generated/schema";
+import { Parcel, TokenCommitment, ERC721Listing } from "../../generated/schema";
 
 import { updatePermissionsFromBitmap } from "../utils/decimals";
 import * as erc7589 from "./erc-7589";
@@ -387,12 +387,11 @@ export function handleSetAavegotchiName(event: SetAavegotchiName): void {
   gotchi.save();
 
   if (gotchi.activeListing) {
-    let listing = getOrCreateERC721Listing(
-      gotchi.activeListing!.toString(),
-      false
-    );
-    listing.nameLowerCase = gotchi.nameLowerCase;
-    listing.save();
+    let listing = ERC721Listing.load(gotchi.activeListing!.toString());
+    if (listing) {
+      listing.nameLowerCase = gotchi.nameLowerCase;
+      listing.save();
+    }
   }
 }
 
@@ -493,12 +492,11 @@ export function handleAavegotchiInteract(event: AavegotchiInteract): void {
 
   // Update ERC721Listing if gotchi has an active listing
   if (gotchi.activeListing) {
-    let listing = getOrCreateERC721Listing(
-      gotchi.activeListing!.toString(),
-      false
-    );
-    listing.kinship = gotchi.kinship;
-    listing.save();
+    let listing = ERC721Listing.load(gotchi.activeListing!.toString());
+    if (listing) {
+      listing.kinship = gotchi.kinship;
+      listing.save();
+    }
   }
 }
 

--- a/src/mappings/diamond.ts
+++ b/src/mappings/diamond.ts
@@ -116,7 +116,7 @@ import {
 } from "../utils/constants";
 import { Address, BigInt, log, Bytes } from "@graphprotocol/graph-ts";
 
-import { Parcel, TokenCommitment } from "../../generated/schema";
+import { Parcel, TokenCommitment, ERC721Listing } from "../../generated/schema";
 
 import { updatePermissionsFromBitmap } from "../utils/decimals";
 import * as erc7589 from "./erc-7589";
@@ -385,12 +385,11 @@ export function handleSetAavegotchiName(event: SetAavegotchiName): void {
   gotchi.save();
 
   if (gotchi.activeListing) {
-    let listing = getOrCreateERC721Listing(
-      gotchi.activeListing!.toString(),
-      false
-    );
-    listing.nameLowerCase = gotchi.nameLowerCase;
-    listing.save();
+    let listing = ERC721Listing.load(gotchi.activeListing!.toString());
+    if (listing) {
+      listing.nameLowerCase = gotchi.nameLowerCase;
+      listing.save();
+    }
   }
 }
 
@@ -493,12 +492,11 @@ export function handleAavegotchiInteract(event: AavegotchiInteract): void {
 
   // Update ERC721Listing if gotchi has an active listing
   if (gotchi.activeListing) {
-    let listing = getOrCreateERC721Listing(
-      gotchi.activeListing!.toString(),
-      false
-    );
-    listing.kinship = gotchi.kinship;
-    listing.save();
+    let listing = ERC721Listing.load(gotchi.activeListing!.toString());
+    if (listing) {
+      listing.kinship = gotchi.kinship;
+      listing.save();
+    }
   }
 }
 

--- a/src/utils/helpers/aavegotchi.ts
+++ b/src/utils/helpers/aavegotchi.ts
@@ -711,7 +711,7 @@ export function createOrUpdateWearablesConfig(
   let contract = AavegotchiDiamond.bind(event.address);
   let ownerAddress = Address.fromString(owner.toHexString());
   let gotchi = getOrCreateAavegotchi(tokenId.toString(), event)!;
-  let user = getOrCreateUser(ownerAddress.toHexString())!;
+  let user = getOrCreateUser(ownerAddress.toHexString());
   let id = `${user.id}-${tokenId}-${wearablesConfigId}`;
 
   let response = contract.try_getWearablesConfig(


### PR DESCRIPTION
## Summary
- avoid crashes when handleAavegotchiInteract is triggered but the listing entity has not been created yet
- load listing defensively in handleSetAavegotchiName and handleAavegotchiInteract

## Testing
- `yarn test:unit` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6853afb431048325a052564af9eba1c3