### PR TITLE
Fix ERC721 listing null crash

### DIFF
--- a/src/utils/helpers/aavegotchi.ts
+++ b/src/utils/helpers/aavegotchi.ts
@@ -471,25 +471,24 @@ export function updateAavegotchiInfo(
     }
 
     if (gotchi.activeListing && updateListing) {
-      let listing = getOrCreateERC721Listing(
-        gotchi.activeListing!.toString(),
-        false
-      );
-      listing.kinship = gotchi.kinship;
-      listing.experience = gotchi.experience;
-      listing.nameLowerCase = gotchi.nameLowerCase;
-      if (
-        gotchi.withSetsNumericTraits != null &&
-        gotchi.withSetsNumericTraits!.length == 6
-      ) {
-        listing.nrgTrait = BigInt.fromI32(gotchi.withSetsNumericTraits![0]);
-        listing.aggTrait = BigInt.fromI32(gotchi.withSetsNumericTraits![1]);
-        listing.spkTrait = BigInt.fromI32(gotchi.withSetsNumericTraits![2]);
-        listing.brnTrait = BigInt.fromI32(gotchi.withSetsNumericTraits![3]);
-        listing.eysTrait = BigInt.fromI32(gotchi.withSetsNumericTraits![4]);
-        listing.eycTrait = BigInt.fromI32(gotchi.withSetsNumericTraits![5]);
+      let listing = ERC721Listing.load(gotchi.activeListing!.toString());
+      if (listing) {
+        listing.kinship = gotchi.kinship;
+        listing.experience = gotchi.experience;
+        listing.nameLowerCase = gotchi.nameLowerCase;
+        if (
+          gotchi.withSetsNumericTraits != null &&
+          gotchi.withSetsNumericTraits!.length == 6
+        ) {
+          listing.nrgTrait = BigInt.fromI32(gotchi.withSetsNumericTraits![0]);
+          listing.aggTrait = BigInt.fromI32(gotchi.withSetsNumericTraits![1]);
+          listing.spkTrait = BigInt.fromI32(gotchi.withSetsNumericTraits![2]);
+          listing.brnTrait = BigInt.fromI32(gotchi.withSetsNumericTraits![3]);
+          listing.eysTrait = BigInt.fromI32(gotchi.withSetsNumericTraits![4]);
+          listing.eycTrait = BigInt.fromI32(gotchi.withSetsNumericTraits![5]);
+        }
+        listing.save();
       }
-      listing.save();
     }
 
     gotchi.locked = gotchiInfo.locked;


### PR DESCRIPTION
## Summary
- guard null ERC721 listings in `updateAavegotchiInfo` to avoid runtime abort

## Testing
- `yarn test:unit` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6882dc43effc83258956798cb390ee79